### PR TITLE
Don't read bDesiredBehindView (for now)

### DIFF
--- a/Classes/PawnCollisionCopy.uc
+++ b/Classes/PawnCollisionCopy.uc
@@ -86,11 +86,16 @@ function SetPawn(Pawn Other)
 		// for weapon pawn, we need the vehicle's collision radius, not the turret
 		if(ONSWeaponPawn(CopiedPawn) != None)
 		{
-			SetCollisionSize(ONSWeaponPawn(CopiedPawn).VehicleBase.CollisionRadius, ONSWeaponPawn(CopiedPawn).VehicleBase.CollisionHeight);
-		}
-		else
-		{
-			SetCollisionSize(CopiedPawn.CollisionRadius, CopiedPawn.CollisionHeight);
+			// Check if the VehicleBase actually exists before accessing its properties
+			if (ONSWeaponPawn(CopiedPawn).VehicleBase != None)
+			{
+				SetCollisionSize(ONSWeaponPawn(CopiedPawn).VehicleBase.CollisionRadius, ONSWeaponPawn(CopiedPawn).VehicleBase.CollisionHeight);
+			}
+			else
+			{
+				// Fallback to the turret's own collision if VehicleBase is missing
+				SetCollisionSize(CopiedPawn.CollisionRadius, CopiedPawn.CollisionHeight);
+			}
 		}
     }
     else

--- a/Classes/UTComp_xPawn.uc
+++ b/Classes/UTComp_xPawn.uc
@@ -1268,10 +1268,12 @@ simulated function Destroyed()
     super.Destroyed();
 }
 
+/* Temporarily disable until behindview is sorted out
 simulated function bool PointOfView()
 {
 	return default.bDesiredBehindView;
 }
+*/
 
 simulated function bool SpecialCalcView(out actor ViewActor, out vector CameraLocation, out rotator CameraRotation )
 {


### PR DESCRIPTION
- Stop unwanted behindview changes like during intermission screens that toggle third person (needs additional logic to prevent this from happening)
- The current third person implementation is unusable anyway