### PR TITLE
Replicate MaxSavedMoves to clients

### DIFF
--- a/Classes/BS_xPlayer.uc
+++ b/Classes/BS_xPlayer.uc
@@ -4005,6 +4005,18 @@ event ClientSetViewTarget(Actor a)
     }
 }
 
+// Configured MaxSavedMoves doesn't get replicated to clients without this -Calypto
+// BS_xPlayer: Exceeded max saved moves (250), consider increasing
+simulated event PostNetReceive()
+{
+	Super.PostNetReceive();
+	
+	if (RepInfo != None && MaxSavedMoves != RepInfo.MaxSavedMoves)
+	{
+		SetMaxSavedMoves();
+	}
+}
+
 // From ModernPlayer by kokuei
 // See PlayerController.uc on how this function works.
 //

--- a/Classes/MutUTComp.uc
+++ b/Classes/MutUTComp.uc
@@ -211,6 +211,7 @@ var UTComp_Whitelist Whitelist;
 var string OriginalStatsClass;
 
 var config bool bDisableCameraShake;
+var config bool bAllowTerrainDodge;
 
 function PreBeginPlay()
 {
@@ -933,6 +934,7 @@ function SpawnReplicationClass()
     RepInfo.TeamRadarCullDistance = TeamRadarCullDistance;
 	
 	RepInfo.bDisableCameraShake = bDisableCameraShake;
+	RepInfo.bAllowTerrainDodge = bAllowTerrainDodge;
 
     for(i=0; i<VotingGametype.Length && i<ArrayCount(RepInfo.VotingNames); i++)
         RepInfo.VotingNames[i]=VotingGametype[i].GameTypeName;
@@ -1684,6 +1686,7 @@ static function FillPlayInfo (PlayInfo PlayInfo)
     PlayInfo.AddSetting("UTComp Settings", "SuicideInterval", "Minimum time between two suicides", security, weight, "Text", "0;0:1800",, False, False);
 	PlayInfo.AddSetting("UTComp Settings", "bDisableCameraShake", "Disable Camera Shake", security, weight, "Check");
 	PlayInfo.AddSetting("UTComp Settings", "bShowTeamScoresInServerBrowser", "Show team scores in server browser", security, weight, "Check");
+	PlayInfo.AddSetting("UTComp Movement", "bAllowTerrainDodge", "Allow dodging off terrain", security, weight, "Check");
     
     weight++;
     PlayInfo.AddSetting("UTComp Settings", "bShowSpawnsDuringWarmup", "Show Spawns during Warmup", security, weight,"Check");
@@ -1784,6 +1787,7 @@ static event string GetDescriptionText(string PropName)
         case "bAllowTeamRadarMap": return "Allow players to use minimap team radar";
 		case "bDisableCameraShake": return "Disable camera shake effects";
 		case "bShowTeamScoresInServerBrowser": return "Check this to show team scores in the server browser";
+		case "bAllowTerrainDodge": return "Allow players to dodge off terrain.";
 
         case "NewNetUpdateFrequency": return "NewNet Update Frequency (200)";
         case "PingTweenTime": return "NewNet Ping Tween Time (3.0)";
@@ -2243,6 +2247,7 @@ defaultproperties
      bAllowTeamRadarMap=false
 	 
 	 bDisableCameraShake=false
+	 bAllowTerrainDodge=false
 
      bUseUTCompStats=true
 

--- a/Classes/UTComp_ServerReplicationInfo.uc
+++ b/Classes/UTComp_ServerReplicationInfo.uc
@@ -83,6 +83,7 @@ var bool bAllowTeamRadarMap;
 var float TeamRadarCullDistance;
 
 var bool bDisableCameraShake;
+var bool bAllowTerrainDodge;
 
 replication
 {
@@ -102,7 +103,7 @@ replication
         bAllowColorWeapons, bDamageIndicator, MaxSavedMoves, bEnableEmoticons, bKeepMomentumOnLanding, NetMoveDelta, 
         MaxResponseTime, bMoveErrorAccumFix, MoveErrorAccumFixValue, bLimitTaunts, TauntCount,
         bAllowTeamRadar, bAllowTeamRadarMap, TeamRadarCullDistance,
-		bDisableCameraShake;
+		bDisableCameraShake, bAllowTerrainDodge;
 }
 
 defaultproperties
@@ -162,5 +163,6 @@ defaultproperties
      TeamRadarCullDistance=10000.0
 	 
 	 bDisableCameraShake=false
+	 bAllowTerrainDodge=false
 }
 

--- a/Classes/UTComp_xPawn.uc
+++ b/Classes/UTComp_xPawn.uc
@@ -1412,6 +1412,62 @@ simulated function byte GetDefaultBrightColorMode()
     return 6;                 // Always Brighter Blue
 }
 
+// Terrain dodging
+function bool Dodge(eDoubleClickDir DoubleClickMove)
+{
+    local vector X, Y, Z, Dir, Cross, TraceDir;
+    local vector TraceStart, TraceEnd, HitLocation, HitNormal;
+    local Actor HitActor;
+    local EPhysics SavedPhysics;
+    local bool bDidDodge;
+
+    if (RepInfo == None)
+    {
+        foreach DynamicActors(class'UTComp_ServerReplicationInfo', RepInfo)
+            break;
+    }
+
+    // Apply custom terrain logic when falling (sliding off steep slopes)
+    if (RepInfo != None && RepInfo.bAllowTerrainDodge && Physics == PHYS_Falling)
+    {
+        GetAxes(Rotation, X, Y, Z);
+        
+        // Determine the dodge direction and cast the trace in the opposite direction
+        if (DoubleClickMove == DCLICK_Forward) { Dir = X; Cross = Y; TraceDir = -X; }
+        else if (DoubleClickMove == DCLICK_Back) { Dir = -X; Cross = Y; TraceDir = X; }
+        else if (DoubleClickMove == DCLICK_Left) { Dir = -Y; Cross = X; TraceDir = Y; }
+        else if (DoubleClickMove == DCLICK_Right) { Dir = Y; Cross = X; TraceDir = -Y; }
+
+        if (AIController(Controller) != None)
+            Cross = vect(0,0,0);
+
+        // Trace horizontally from the feet
+        TraceStart = Location - vect(0,0,1) * (CollisionHeight - 4.0); 
+        TraceEnd = TraceStart + TraceDir * (CollisionRadius + 32.0);
+
+        // false = ignore actors, only trace world geometry (Terrain)
+        HitActor = Trace(HitLocation, HitNormal, TraceEnd, TraceStart, false);
+
+        // If we hit terrain, verify the angle opposes the dodge direction.
+        // (Dir Dot HitNormal > 0 ensures we are dodging away from the slope's face)
+        if (HitActor != None && HitActor.IsA('TerrainInfo') && (Dir Dot HitNormal) > 0)
+        {
+            SavedPhysics = Physics;
+            SetPhysics(PHYS_Falling);
+            
+            bDidDodge = PerformDodge(DoubleClickMove, Dir, Cross);
+            
+            // Restore physics state if the dodge failed or didn't lift us
+            if (!bDidDodge || Physics == PHYS_Walking)
+                SetPhysics(SavedPhysics);
+
+            return bDidDodge;
+        }
+    }
+
+    return Super.Dodge(DoubleClickMove);
+}
+
 defaultproperties
 {
     bAlwaysRelevant=True


### PR DESCRIPTION
The client log would show this despite the server's configured value being higher:
`BS_xPlayer: Exceeded max saved moves (250), consider increasing`